### PR TITLE
Fixed xPlayer nil value

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -24,9 +24,8 @@ function SendNewData()
     end
 	
     local xPlayers = ESX.GetExtendedPlayers()
-	for k, v in pairs(xPlayers) do
+	for k, xPlayer in pairs(xPlayers) do
 		if Showuser(xPlayer.source) then
-            local xPlayer = ESX.GetPlayerFromId(xPlayer.source)
 			noplayers = false
 
 			local coords = xPlayer.coords

--- a/server.lua
+++ b/server.lua
@@ -28,7 +28,7 @@ function SendNewData()
 		if Showuser(xPlayer.source) then
 			noplayers = false
 
-			local coords = xPlayer.coords
+			local coords = xPlayer.getCoords()
             deb(type(coords))
 
 			local name = GetDisplayName(xPlayer.source, xPlayer.name)
@@ -38,11 +38,7 @@ function SendNewData()
 			d["name"] = name
             d["system"] = Config.Jobs[xPlayer.job.name]["system"]
 			
-            if type(coords) == "table" then
-                d["location"] = coords
-            else
-                d["location"] = xPlayer.getCoords()
-            end
+            d["location"] = coords
 
             d["style"] = GetStyle(xPlayer.source, xPlayer.job)
 			table.insert(data, d)


### PR DESCRIPTION
server.lua:28: attempt to index a nil value (global 'xPlayer') 
xPlayer was not defined prior to usage in L28

Testet on Server with es_extended v1.10.2, on fxserver artifact b7290 on windows

@Miho931 Kannst du da mal drüber schauen? Das waren deine Changes, ob das tatsächlich ein Bug ist, oder ob ich irgendwas übersehen habe. Falls der pull-request, dass deiner Ansicht nach fixed, bitte mergen